### PR TITLE
[feat] add basic TLS support for HTTPS registry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,10 @@
 *.so
 *.dylib
 
+# IDEs/Editors
+.idea
+.vscode
+
 # Test binary, built with `go test -c`
 *.test
 

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ lint: $(GOMETALINTER)
 ## build: Builds project into an executable binary.
 .PHONY: build
 build:
-	go build -o bin/ipdr cmd/ipdr/ipdr.go
+	go build -o bin/ipdr cmd/ipdr/main.go
 
 ## release: Release a new version. Runs `goreleaser internally.
 .PHONY: release

--- a/README.md
+++ b/README.md
@@ -272,6 +272,10 @@ make test
 
   - A: Use the `--port` flag, eg. `--port 5000`
 
+- Q: How can I use a HTTPS-secured registry when using `server`?
+
+  - A: Use the `--tlsKeyPath` and `--tlsCrPath` flag, eg. ` --tlsKeyPath path/server.key --tlsCrtPath path/server.crt`
+
 ## Contributing
 
 Pull requests are welcome!

--- a/cmd/ipdr/main.go
+++ b/cmd/ipdr/main.go
@@ -34,6 +34,8 @@ func main() {
 	var format string
 	var dockerRegistryHost string
 	var port uint
+	var tlsCrtPath string
+	var tlsKeyPath string
 	var silent bool
 
 	rootCmd := &cobra.Command{
@@ -138,6 +140,8 @@ More info: https://github.com/miguelmota/ipdr`,
 			srv := server.NewServer(&server.Config{
 				Port:  port,
 				Debug: !silent,
+				TLSKeyPath: tlsKeyPath,
+				TLSCrtPath: tlsCrtPath,
 			})
 
 			return srv.Start()
@@ -146,6 +150,8 @@ More info: https://github.com/miguelmota/ipdr`,
 
 	serverCmd.Flags().BoolVarP(&silent, "silent", "s", false, "Silent flag suppresses logs")
 	serverCmd.Flags().UintVarP(&port, "port", "p", 5000, "The port for the Docker registry to listen on")
+	serverCmd.Flags().StringVarP(&tlsCrtPath, "tlsCrtPath", "", "", "The path to the .crt file for TLS")
+	serverCmd.Flags().StringVarP(&tlsKeyPath, "tlsKeyPath", "", "", "The path to the .key file for TLS")
 
 	convertCmd := &cobra.Command{
 		Use:   "convert",

--- a/cmd/ipdr/main.go
+++ b/cmd/ipdr/main.go
@@ -142,6 +142,7 @@ More info: https://github.com/miguelmota/ipdr`,
 				Debug: !silent,
 				TLSKeyPath: tlsKeyPath,
 				TLSCrtPath: tlsCrtPath,
+				IPFSGateway: ipfsGateway,
 			})
 
 			return srv.Start()
@@ -152,6 +153,7 @@ More info: https://github.com/miguelmota/ipdr`,
 	serverCmd.Flags().UintVarP(&port, "port", "p", 5000, "The port for the Docker registry to listen on")
 	serverCmd.Flags().StringVarP(&tlsCrtPath, "tlsCrtPath", "", "", "The path to the .crt file for TLS")
 	serverCmd.Flags().StringVarP(&tlsKeyPath, "tlsKeyPath", "", "", "The path to the .key file for TLS")
+	serverCmd.Flags().StringVarP(&ipfsGateway, "ipfs-gateway", "g", "127.0.0.1:8080", "The readonly IPFS Gateway URL to pull the image from. Eg. https://ipfs.io")
 
 	convertCmd := &cobra.Command{
 		Use:   "convert",

--- a/server/server.go
+++ b/server/server.go
@@ -114,7 +114,11 @@ func (s *Server) Start() error {
 		if strings.HasSuffix(uri, "/latest") {
 			// docker daemon requesting the manifest
 			suffix = "-v1"
+			// If multiple mediaTypes in Accept-Header cannot be resolved to an array split it by ','
 			accepts := r.Header["Accept"]
+			if len(accepts) == 1 && strings.Contains(accepts[0], ",") {
+				accepts = strings.Split(accepts[0], ",")
+			}
 			for _, accept := range accepts {
 				if accept == contentTypes["manifestV2Schema"] ||
 					accept == contentTypes["manifestListV2Schema"] {

--- a/server/server.go
+++ b/server/server.go
@@ -19,6 +19,8 @@ type Server struct {
 	listener    net.Listener
 	host        string
 	ipfsGateway string
+	tlsCrtPath 	string
+	tlsKeyPath	string
 }
 
 // Config is server config
@@ -26,6 +28,8 @@ type Config struct {
 	Debug       bool
 	Port        uint
 	IPFSGateway string
+	TLSCrtPath 	string
+	TLSKeyPath	string
 }
 
 // InfoResponse is response for manifest info response
@@ -59,6 +63,8 @@ func NewServer(config *Config) *Server {
 		host:        fmt.Sprintf("0.0.0.0:%v", port),
 		debug:       config.Debug,
 		ipfsGateway: ipfs.NormalizeGatewayURL(config.IPFSGateway),
+		tlsCrtPath:  config.TLSCrtPath,
+		tlsKeyPath:  config.TLSKeyPath,
 	}
 }
 
@@ -171,7 +177,9 @@ func (s *Server) Start() error {
 	}
 
 	s.Debugf("[registry/server] listening on %s", s.listener.Addr())
-
+	if s.tlsKeyPath != "" && s.tlsCrtPath != "" {
+		return http.ServeTLS(s.listener, nil, s.tlsCrtPath, s.tlsKeyPath)
+	}
 	return http.Serve(s.listener, nil)
 }
 


### PR DESCRIPTION
This PR introduces two path parameters to the `server` command for a `.key` and `.crt` file. If provided, the server is reachable with HTTPS.
This can be useful if only secure docker registries are allowed.

Example: `ipdr server --tlsKeyPath path/server.key --tlsCrtPath path/server.crt`