### PR TITLE
Add drop-in replacement for http.Get with timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ High-level overview:
 
     ```hosts
     echo '127.0.0.1 docker.local' | sudo tee -a /etc/hosts
+    echo '::1       docker.local' | sudo tee -a /etc/hosts
     ```
 
     - Flush local DNS cache:

--- a/regutil/regutil.go
+++ b/regutil/regutil.go
@@ -8,6 +8,8 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/miguelmota/ipdr/netutil"
+
 	cid "github.com/ipfs/go-cid"
 	base58 "github.com/jbenet/go-base58"
 	mbase "github.com/multiformats/go-multibase"
@@ -86,7 +88,7 @@ func ToB32(s string) string {
 func Dig(gw string, short bool, name string) (string, error) {
 	uri := fmt.Sprintf("http://%s/dig?q=%s&short=%v", gw, name, short)
 
-	resp, err := http.Get(uri)
+	resp, err := netutil.Get(uri)
 	if err != nil {
 		return "", err
 	}

--- a/server/registry/blobs.go
+++ b/server/registry/blobs.go
@@ -26,6 +26,8 @@ import (
 	"path"
 	"strings"
 	"sync"
+
+	"github.com/miguelmota/ipdr/netutil"
 )
 
 // Returns whether this url should be handled by the blob handler
@@ -148,7 +150,7 @@ func (b *blobs) handle(resp http.ResponseWriter, req *http.Request) *regError {
 			}
 		}
 		uri := b.registry.ipfsURL([]string{cid, "blobs", target})
-		ipfsResp, err := http.Get(uri)
+		ipfsResp, err := netutil.Get(uri)
 		if err != nil {
 			return &regError{
 				Status:  http.StatusNotFound,

--- a/server/registry/cids.go
+++ b/server/registry/cids.go
@@ -18,9 +18,6 @@ type cidStore struct {
 }
 
 func key(repo, ref string) string {
-	if ref == "" {
-		ref = "latest"
-	}
 	return repo + ":" + ref
 }
 

--- a/server/registry/registry.go
+++ b/server/registry/registry.go
@@ -176,6 +176,8 @@ func (r *registry) resolveCID(repo, reference string) (string, error) {
 }
 
 func (r *registry) resolve(repo, reference string) []string {
+	r.log.Printf("resolving CID: %s:%s", repo, reference)
+
 	// local/cached
 	if cid, ok := r.cids.Get(repo, reference); ok {
 		return []string{cid}

--- a/server/registry/util.go
+++ b/server/registry/util.go
@@ -5,12 +5,13 @@ import (
 	"io/ioutil"
 	"net/http"
 
+	"github.com/miguelmota/ipdr/netutil"
 	"github.com/miguelmota/ipdr/regutil"
 )
 
 func getContent(gw string, cid string, s []string) ([]byte, error) {
 	uri := regutil.IpfsURL(gw, append([]string{cid}, s...))
-	resp, err := http.Get(uri)
+	resp, err := netutil.Get(uri)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Add drop-in replacement for http.Get with timeout

Update README - docker.local IPv6 address which fixes 5 seconds delay (a known IPv6 issue)
test with/without the host entry e.g.: ipdr dig or curl -4/curl -6
hello/test.sh runs in 3m51s vs 0m28s

IPv6 related issues:
https://blog.csuttles.io/post/troubleshooting-a-slow-client/
https://www.math.tamu.edu/~comech/tools/linux-slow-dns-lookup/